### PR TITLE
(#22) Bump Spectre.Console to v 0.45.0

### DIFF
--- a/src/Spectre.Console.Registrars.Microsoft-Di.Tests/Spectre.Console.Registrars.Microsoft-Di.Tests.csproj
+++ b/src/Spectre.Console.Registrars.Microsoft-Di.Tests/Spectre.Console.Registrars.Microsoft-Di.Tests.csproj
@@ -12,13 +12,13 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
-        <PackageReference Include="Spectre.Console" Version="0.44.0" />
-        <PackageReference Include="Spectre.Console.Testing" Version="0.44.0" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+        <PackageReference Include="Spectre.Console.Testing" Version="0.45.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.analyzers" Version="1.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Spectre.Console.Registrars.Microsoft-Di/Spectre.Console.Registrars.Microsoft-Di.csproj
+++ b/src/Spectre.Console.Registrars.Microsoft-Di/Spectre.Console.Registrars.Microsoft-Di.csproj
@@ -31,13 +31,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Spectre.Console" Version="0.44.0" PrivateAssets="all" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This also contains a switch from Spectre.Console to Spectre.Console.Cli

fixes #22 